### PR TITLE
feat: Add zstd support for reading and writing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Developers",
 ]
-dependencies = ["numpy>=1.21", "packaging"]
+dependencies = ["numpy>=1.21", "packaging", "backports.zstd"]
 dynamic = ["version"]
 
 [project.urls]

--- a/src/pyhepmc/io.py
+++ b/src/pyhepmc/io.py
@@ -247,6 +247,14 @@ class HepMCFile:
                 import lzma
 
                 open = lzma.open  # type:ignore
+            elif fn.endswith(".zst") or fn.endswith(".zstd"):
+                from sys import version_info
+
+                if version_info >= (3, 14):
+                    from compression import zstd
+                else:
+                    from backports import zstd
+                open = zstd.open
             else:
                 from builtins import open  # type:ignore
 


### PR DESCRIPTION
This uses the `compression.zstd` module in Python 3.14 and `backports.zstd` (unconditionally installed from pypi) for lower versions