### PR TITLE
Add `add_tree` function to GenEvent

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -536,6 +536,7 @@ PYBIND11_MODULE(_core, m) {
       METH(set_units, GenEvent)
       METH(event_pos, GenEvent)
       PROP_RO_OL(beams, GenEvent, std::vector<ConstGenParticlePtr>)
+      METH(add_tree, GenEvent)
       METH_OL(add_vertex, GenEvent, void, GenVertexPtr)
       METH_OL(add_particle, GenEvent, void, GenParticlePtr)
       METH(set_beam_particles, GenEvent)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,76 @@ from numpy.testing import assert_equal
 import numpy as np
 
 
+def create_event_components():
+    r"""
+    In this example we will generate the following event by hand
+
+        name status pdg_id      parent Px       Py     Pz       Energy      Mass
+     1  !p+!    1   2212        0,0    0.000    0.000  7000.000 7000.000    0.938
+     2  !He4!   2   1000020040  0,0    0.000    0.000 -7000.000 7000.000    3.756
+    =============================================================================
+     3  !d!     3      1        1,1    0.750   -1.569    32.191   32.238    0.000
+     4  !u~!    4     -2        2,2   -3.047  -19.000   -54.629   57.920    0.000
+     5  !W-!    5    -24        3,4    1.517   -20.68   -20.605   85.925   80.799
+     6  !gamma! 6     22        3,4   -3.813    0.113    -1.833    4.233    0.000
+     7  !d!     7      1        5,5   -2.445   28.816     6.082   29.552    0.010
+     8  !u~!    8     -2        5,5    3.962  -49.498   -26.687   56.373    0.006
+
+    The corresponding graph looks like this
+
+                           p7
+     p1                   /
+       \v1__p3      p5---v4
+             \_v3_/       \
+             /    \        p8
+        v2__p4     \
+       /            p6
+     p2
+    """
+    #                     px   py   pz      e        pdgid status
+    p1 = hep.GenParticle((0.0, 0.0, 7000.0, 7000.0), 2212, 1)
+    p1.generated_mass = 0.938
+    p2 = hep.GenParticle((0.0, 0.0, -7000.0, 7000.0), 1000020040, 2)
+    p2.generated_mass = 3.756
+    p3 = hep.GenParticle((0.750, -1.569, 32.191, 32.238), 1, 3)
+    p3.generated_mass = 0
+    p4 = hep.GenParticle((-3.047, -19.0, -54.629, 57.920), -2, 4)
+    p4.generated_mass = 0
+    p5 = hep.GenParticle((1.517, -20.68, -20.605, 85.925), -24, 5)
+    p5.generated_mass = 80.799
+    p6 = hep.GenParticle((-3.813, 0.113, -1.833, 4.233), 22, 6)
+    p6.generated_mass = 0
+    p7 = hep.GenParticle((-2.445, 28.816, 6.082, 29.552), 1, 7)
+    p7.generated_mass = 0.01
+    p8 = hep.GenParticle((3.962, -49.498, -26.687, 56.373), -2, 8)
+    p8.generated_mass = 0.006
+
+    # make sure vertex is not optimized away by WriterAscii
+    v1 = hep.GenVertex((1.0, 1.0, 1.0, 1.0))
+    v1.add_particle_in(p1)
+    v1.add_particle_out(p3)
+
+    # make sure vertex is not optimized away by WriterAscii
+    v2 = hep.GenVertex((2.0, 2.0, 2.0, 2.0))
+    v2.add_particle_in(p2)
+    v2.add_particle_out(p4)
+
+    # make sure vertex is not optimized away by WriterAscii
+    v3 = hep.GenVertex((3.0, 3.0, 3.0, 3.0))
+    v3.add_particle_in(p3)
+    v3.add_particle_in(p4)
+    v3.add_particle_out(p5)
+    v3.add_particle_out(p6)
+
+    # make sure vertex is not optimized away by WriterAscii
+    v4 = hep.GenVertex((4.0, 4.0, 4.0, 4.0))
+    v4.add_particle_in(p5)
+    v4.add_particle_out(p7)
+    v4.add_particle_out(p8)
+
+    return [p1, p2, p3, p4, p5, p6, p7, p8], [v1, v2, v3, v4]
+
+
 def make_evt():
     r"""
     In this example we will generate the following event by hand
@@ -35,58 +105,11 @@ def make_evt():
     evt = hep.GenEvent(hep.Units.GEV, hep.Units.MM)
     evt.event_number = 1
 
-    #                     px   py   pz      e        pdgid status
-    p1 = hep.GenParticle((0.0, 0.0, 7000.0, 7000.0), 2212, 1)
-    p1.generated_mass = 0.938
-    p2 = hep.GenParticle((0.0, 0.0, -7000.0, 7000.0), 1000020040, 2)
-    p2.generated_mass = 3.756
-    p3 = hep.GenParticle((0.750, -1.569, 32.191, 32.238), 1, 3)
-    p3.generated_mass = 0
-    p4 = hep.GenParticle((-3.047, -19.0, -54.629, 57.920), -2, 4)
-    p4.generated_mass = 0
-    p5 = hep.GenParticle((1.517, -20.68, -20.605, 85.925), -24, 5)
-    p5.generated_mass = 80.799
-    p6 = hep.GenParticle((-3.813, 0.113, -1.833, 4.233), 22, 6)
-    p6.generated_mass = 0
-    p7 = hep.GenParticle((-2.445, 28.816, 6.082, 29.552), 1, 7)
-    p7.generated_mass = 0.01
-    p8 = hep.GenParticle((3.962, -49.498, -26.687, 56.373), -2, 8)
-    p8.generated_mass = 0.006
-    evt.add_particle(p1)
-    evt.add_particle(p2)
-    evt.add_particle(p3)
-    evt.add_particle(p4)
-    evt.add_particle(p5)
-    evt.add_particle(p6)
-    evt.add_particle(p7)
-    evt.add_particle(p8)
-
-    # make sure vertex is not optimized away by WriterAscii
-    v1 = hep.GenVertex((1.0, 1.0, 1.0, 1.0))
-    v1.add_particle_in(p1)
-    v1.add_particle_out(p3)
-    evt.add_vertex(v1)
-
-    # make sure vertex is not optimized away by WriterAscii
-    v2 = hep.GenVertex((2.0, 2.0, 2.0, 2.0))
-    v2.add_particle_in(p2)
-    v2.add_particle_out(p4)
-    evt.add_vertex(v2)
-
-    # make sure vertex is not optimized away by WriterAscii
-    v3 = hep.GenVertex((3.0, 3.0, 3.0, 3.0))
-    v3.add_particle_in(p3)
-    v3.add_particle_in(p4)
-    v3.add_particle_out(p5)
-    v3.add_particle_out(p6)
-    evt.add_vertex(v3)
-
-    # make sure vertex is not optimized away by WriterAscii
-    v4 = hep.GenVertex((4.0, 4.0, 4.0, 4.0))
-    v4.add_particle_in(p5)
-    v4.add_particle_out(p7)
-    v4.add_particle_out(p8)
-    evt.add_vertex(v4)
+    particles, vertices = create_event_components()
+    for p in particles:
+        evt.add_particle(p)
+    for v in vertices:
+        evt.add_vertex(v)
 
     evt.weights = [1.0]
 
@@ -102,6 +125,17 @@ def make_evt():
 @pytest.fixture()
 def evt():
     return make_evt()
+
+
+def test_GenEvent_add_tree():
+    evt1 = make_evt()
+    particles, _ = create_event_components()
+    evt2 = hep.GenEvent(hep.Units.GEV, hep.Units.MM)
+    evt2.add_tree(particles)
+    assert len(evt2.particles) == len(evt1.particles)
+    assert hep.equal_particle_sets(evt2.particles, evt1.particles)
+    assert len(evt2.vertices) == len(evt1.vertices)
+    assert hep.equal_vertex_sets(evt2.vertices, evt1.vertices)
 
 
 def test_GenHeavyIon():


### PR DESCRIPTION
Adds `GenEvent::add_tree` function to `pyhepmc`

This is required to mimic behavior of [`Pythia8ToHepMC3`](https://gitlab.cern.ch/hepmc/HepMC3/-/blob/master/python/test/Pythia8ToHepMC3.py) in pure `pyhepmc`.